### PR TITLE
small typo and added the word (Matrix)

### DIFF
--- a/views/public/about.pug
+++ b/views/public/about.pug
@@ -24,7 +24,7 @@ block content
                         | Join us for collaboration on
                         a.left(href='https://discord.gg/ejGah8H') Discord
                         | ,
-                        a.left(href='https://riot.im/app/#/room/#nodetube:matrix.org') Riot.Im
+                        a.left(href='https://riot.im/app/#/room/#nodetube:matrix.org') Riot.im (Matrix)
                         |  and
                         a.left(href='https://reddit.com/r/nodetube') Reddit
 


### PR DESCRIPTION
changed from Riot.Im to Riot.im
and I've added Matrix in round brackets (that's how it's usually done) because Riot is just one of the many clients while the protocol is Matrix https://matrix.org/clients/ - riot is just one of the many