### PR TITLE
correct GitHub capitalization

### DIFF
--- a/views/partials/footer.pug
+++ b/views/partials/footer.pug
@@ -4,7 +4,7 @@ footer
 
     a.pull-left(style="color:#aaa;margin-right:10px;" href="/termsofservice") Terms Of Service
 
-    a.pull-left(style="color:#aaa;margin-right:10px;text-decoration:underline;" href="https://github.com/mayeaux/nodetube") Github
+    a.pull-left(style="color:#aaa;margin-right:10px;text-decoration:underline;" href="https://github.com/mayeaux/nodetube") GitHub
 
     a.pull-left(style="color:#aaa;margin-right:10px;text-decoration:underline;" href="https://discord.gg/ejGah8H") Discord
 

--- a/views/public/about.pug
+++ b/views/public/about.pug
@@ -15,7 +15,7 @@ block content
 
                 h3 NodeTube was created to allow anyone with basic technical skills to run their own media hosting platform
                 br
-                h3 Please check out the Github repo for more information
+                h3 Please check out the GitHub repo for more information
                         a(style="margin-left:5px" href="https://github.com/mayeaux/nodetube").
                                   here
 


### PR DESCRIPTION
Fixes the GitHub capitalisation in the page footer and the about page.

I saw you ask in your Reddit thread :)