### PR TITLE
Updated Plyr to version 3.3.21. Hides cursor in full screen mode

### DIFF
--- a/views/media.pug
+++ b/views/media.pug
@@ -16,7 +16,7 @@ block content
             div.display-div(style="min-width:50%;min-height:50%;margin:0 auto;")
                 // TODO: Sub out thumbnail here
 
-                video.display-element(poster=`${uploadServer}/${upload.uploader.channelUrl}/${upload.thumbnails.generated || upload.thumbnails.medium}` controls='', style="max-width:100%;background-color:black;")
+                video#media_player.display-element(poster=`${uploadServer}/${upload.uploader.channelUrl}/${upload.thumbnails.generated || upload.thumbnails.medium}` controls='', style="max-width:100%;background-color:black;")
                     // to
                     source.video-source(src=`${uploadServer}/${upload.uploader.channelUrl}/${upload.uniqueTag}.mp4`, type='video/mp4')
                     //source(src=upload.uploadUrl, type='video/mp4')
@@ -337,7 +337,7 @@ block extra_js
 
 
 block extra_css
-  link(rel="stylesheet" href="https://cdn.plyr.io/2.0.16/plyr.css")
+  link(rel="stylesheet" href="https://cdn.plyr.io/3.3.21/plyr.css")
   style.
     .pewtube-pro {
         background: #edeeee;
@@ -368,7 +368,7 @@ block extra_css
 
 block extra_footer_js
   script(src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js")
-  script(src="https://cdn.plyr.io/2.0.16/plyr.js")
+  script(src="https://cdn.plyr.io/3.3.21/plyr.js")
   script.
     var clipboard = new ClipboardJS('.copy-button');
 

--- a/views/mediaPlayerPartials/plyrAndAutoplayFunctionalityJs.pug
+++ b/views/mediaPlayerPartials/plyrAndAutoplayFunctionalityJs.pug
@@ -41,16 +41,16 @@ script.
   var plyr_options = {
     autoplay: autoplay,
     clickToPlay: true,
-    controls: ['mute', 'progress', 'play', 'fullscreen', 'volume', 'play-large', 'current-time']
+    controls: ['mute', 'progress', 'play', 'fullscreen', 'volume', 'play-large', 'current-time', 'settings'],
+    settings: ['speed'],
   };
 
   // Create the plyr instances - this defines players[0] as our primary player.
-  var players = plyr.setup(plyr_options);
+  var players = Plyr.setup("#media_player", plyr_options);
 
   players[0].on('ready', function (event) {
-    $('.display-element').css('max-height', '620px')
-
     // set video max-height to 620px
+    $('.display-element').css('max-height', '620px');
   });
 
   players[0].on('enterfullscreen', function (event) {


### PR DESCRIPTION
This change updates the version of Plyr used to version 3.3.21. The original motivation behind the update was to get the Speed option in the player menu. As discussed in issue #54, later versions of Plyr automatically hide the mouse cursor in full screen mode so that problem is fixed with these changes.