### PR TITLE
Use updated Plyr for audio player

### DIFF
--- a/views/media.pug
+++ b/views/media.pug
@@ -23,7 +23,7 @@ block content
 
         else if upload.fileType === 'audio'
             div
-                audio.my_audio(style="width:80%;" controls='', preload='none')
+                audio#media_player.my_audio(style="width:80%;" controls='', preload='none')
 
                     if upload.fileExtension == '.m4a'
                         source(src=`${uploadServer}/${upload.uploader.channelUrl}/${upload.uniqueTag}${upload.fileExtension}`, type='audio/mp4')


### PR DESCRIPTION
The ID selector was not carried over for the audio player portion in the media page. That resulted in the browser controls being used for the audio player rather than Plyr. This change makes sure Plyr is hooked into the audio player.