### PR TITLE
fix: bad container names.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3.1'
+
 services:
   node:
+    container_name: nodetube
     build:
       context: .
       dockerfile: Dockerfile
@@ -13,7 +15,7 @@ services:
       - ./uploads:/app/uploads
     environment:
       - REDIS_HOST=redis
-      - MONGODB_DOCKER_URI=mongodb://mongo:27017/nodetube
+      - MONGODB_DOCKER_URI=mongodb://nodetube-mongo:27017/nodetube
     depends_on:
       - redis
       - mongo
@@ -22,7 +24,7 @@ services:
       - nodetube-network
 
   mongo:
-    container_name: mongodb
+    container_name: nodetube-mongo
     image: mongo:3.6
     volumes:
       - ./data/db:/data/db
@@ -32,9 +34,11 @@ services:
       - nodetube-network
 
   redis:
+    container_name: nodetube-redis
     image: redis
     networks:
       - nodetube-network
+
 networks:
   nodetube-network:
     driver: bridge


### PR DESCRIPTION
My instance of Docker has many applications hosted beside nodetube. So a good container name is important to me. That way, I can identify the containers just by seeing them. 

Currently, our containers do not have a name pattern. To fix it, I renamed the nodetube containers using a prefix pattern. This is the pattern I use in all my projects.

Tell me your opinion about this. I would like us to approve this.

Before:
![image](https://user-images.githubusercontent.com/22862212/71785660-05d1bd00-2fe1-11ea-9778-d57402b5b546.png)

After:
![image](https://user-images.githubusercontent.com/22862212/71785710-914b4e00-2fe1-11ea-8c18-a7d71d6027d8.png)
