### PR TITLE
fix: docker build not cache npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,20 @@
 FROM node:8-alpine
-RUN apk add  --no-cache ffmpeg
-RUN apk add  --no-cache git
-RUN apk add  --no-cache tar
-#RUN set -ex && apk --no-cache add sudo
 
-COPY . /app
+RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache git
+RUN apk add --no-cache tar
 
-# Create app directory
-WORKDIR /app
+WORKDIR /app/
 
-# Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
-COPY bower.json ./
-#COPY .bowerrc ./
+COPY package*.json /app/
+COPY bower.json /app/
 
-#RUN npm i node-sass@latest
 RUN npm i
 RUN npm i -g bower
 RUN bower install --allow-root
-#RUN npm run installDeps
-# If you are building for production
-# RUN npm install --only=production
 
-
-# Bundle app source
 COPY . .
 
 EXPOSE 8080
 
-CMD [ "npm", "start" ]
+CMD ["npm", "start"]


### PR DESCRIPTION
The docker build time is currently bigger than expected. One reason is that the `npm install` execution is not cached.

I solved this using [this tip](https://www.aptible.com/documentation/faq/deploy/dockerfile-caching/npm-dockerfile-caching.html). You can read more about the solution [here](https://stackoverflow.com/questions/35774714/how-to-cache-the-run-npm-install-instruction-when-docker-build-a-dockerfile).

This should have no impact except to improve of the docker build time after the first build.