### PR TITLE
fix: usage of nonexistent bower dependencies

### DIFF
--- a/views/livestream/staging.pug
+++ b/views/livestream/staging.pug
@@ -2,13 +2,7 @@ extends ../layout
 
 block content
     body
-        link(rel='stylesheet', href='/bower_components/demo-console/index.css')
-        link(rel='stylesheet', href='/bower_components/ekko-lightbox/dist/ekko-lightbox.min.css')
         link(rel='stylesheet', href='/css/kurento.css')
-        script(src='/bower_components/adapter.js/adapter.js')
-        script(src='/bower_components/demo-console/index.js')
-        script(src='/bower_components/ekko-lightbox/dist/ekko-lightbox.min.js')
-        script(src='/bower_components/kurento-utils/js/kurento-utils.js')
         script(src='/js/livestreaming/getScreenId.js')
         script(src='/js/livestreaming/screensharing.js')
         //script(src='/js/livestreaming/index.js')

--- a/views/livestream/view.pug
+++ b/views/livestream/view.pug
@@ -2,13 +2,7 @@ extends ../layout
 
 block content
     body
-        link(rel='stylesheet', href='/bower_components/demo-console/index.css')
-        link(rel='stylesheet', href='/bower_components/ekko-lightbox/dist/ekko-lightbox.min.css')
         link(rel='stylesheet', href='/css/kurento.css')
-        script(src='/bower_components/adapter.js/adapter.js')
-        script(src='/bower_components/demo-console/index.js')
-        script(src='/bower_components/ekko-lightbox/dist/ekko-lightbox.min.js')
-        script(src='/bower_components/kurento-utils/js/kurento-utils.js')
         script(src='/js/livestreaming/getScreenId.js')
         script(src='/js/livestreaming/screensharing.js')
         //script(src='/js/livestreaming/index.js')


### PR DESCRIPTION
We removed some bower dependencies in [this commit](https://github.com/mayeaux/nodetube/commit/5c16d8f2991227ac59035dcb3490b947619e654f). But, we do not remove the usages of this dependencies in the headers.

To be clear to everyone I'm fixing it.