### PR TITLE
Videos over 1000MB show size in GB

### DIFF
--- a/controllers/backend/uploading.js
+++ b/controllers/backend/uploading.js
@@ -14,6 +14,7 @@ const redisClient = require('../../config/redis');
 
 const pagination = require('../../lib/helpers/pagination');
 const timeHelper = require('../../lib/helpers/time');
+const uploadingHelpers = require('../../lib/uploading/helpers');
 
 const User = require('../../models/index').User;
 const Upload = require('../../models/index').Upload;
@@ -207,10 +208,6 @@ const testIsFileTypeUnknown = async function(upload, fileType, fileExtension, lo
 
 };
 
-const bytesToMb = (bytes, decimalPlaces = 4) => {
-  return(bytes / Math.pow(10,6)).toFixed(decimalPlaces);
-};
-
 /**
  * POST /api/upload
  * File Upload API example.
@@ -273,7 +270,8 @@ exports.postFileUpload = async(req, res) => {
       let fileExtension = getExtensionString(filename);
 
       const fileSize = resumableTotalSize;
-      const originalFileSizeInMb = bytesToMb(resumableTotalSize);
+      const originalFileSizeInMb = uploadingHelpers.bytesToMb(resumableTotalSize);
+      const originalFileSizeInGb = uploadingHelpers.bytesToGb(resumableTotalSize);
 
       if(fileExtension == '.MP4'){
         fileExtension = '.mp4';
@@ -300,6 +298,7 @@ exports.postFileUpload = async(req, res) => {
         fileExtension,
         fileSize,
         originalFileSizeInMb,
+        originalFileSizeInGb,
         category,
         subcategory,
         rating,
@@ -497,7 +496,8 @@ exports.postFileUpload = async(req, res) => {
 
               // Save file size after compression.
               const response = await ffmpegHelper.ffprobePromise(fileInDirectory);
-              upload.processedFileSizeInMb = bytesToMb(response.format.size);
+              upload.processedFileSizeInMb = uploadingHelpers.bytesToMb(response.format.size);
+              upload.processedFileSizeInGb = uploadingHelpers.bytesToGb(response.format.size)
 
               await upload.save();
 
@@ -623,7 +623,8 @@ exports.adminUpload = async(req, res) => {
     // console.log(response);
 
     upload.fileSize = response.format.size;
-    upload.processedFileSizeInMb = bytesToMb(response.format.size);
+    upload.processedFileSizeInMb = uploadingHelpers.bytesToMb(response.format.size);
+    upload.processedFileSizeInGb = uploadingHelpers.bytesToGb(response.format.size);
 
     upload.bitrate = response.format.bit_rate / 1000;
 

--- a/controllers/backend/uploading.js
+++ b/controllers/backend/uploading.js
@@ -271,7 +271,6 @@ exports.postFileUpload = async(req, res) => {
 
       const fileSize = resumableTotalSize;
       const originalFileSizeInMb = uploadingHelpers.bytesToMb(resumableTotalSize);
-      const originalFileSizeInGb = uploadingHelpers.bytesToGb(resumableTotalSize);
 
       if(fileExtension == '.MP4'){
         fileExtension = '.mp4';
@@ -298,7 +297,6 @@ exports.postFileUpload = async(req, res) => {
         fileExtension,
         fileSize,
         originalFileSizeInMb,
-        originalFileSizeInGb,
         category,
         subcategory,
         rating,
@@ -497,7 +495,6 @@ exports.postFileUpload = async(req, res) => {
               // Save file size after compression.
               const response = await ffmpegHelper.ffprobePromise(fileInDirectory);
               upload.processedFileSizeInMb = uploadingHelpers.bytesToMb(response.format.size);
-              upload.processedFileSizeInGb = uploadingHelpers.bytesToGb(response.format.size)
 
               await upload.save();
 
@@ -624,7 +621,6 @@ exports.adminUpload = async(req, res) => {
 
     upload.fileSize = response.format.size;
     upload.processedFileSizeInMb = uploadingHelpers.bytesToMb(response.format.size);
-    upload.processedFileSizeInGb = uploadingHelpers.bytesToGb(response.format.size);
 
     upload.bitrate = response.format.bit_rate / 1000;
 

--- a/controllers/backend/uploading.js
+++ b/controllers/backend/uploading.js
@@ -16,6 +16,8 @@ const pagination = require('../../lib/helpers/pagination');
 const timeHelper = require('../../lib/helpers/time');
 const uploadingHelpers = require('../../lib/uploading/helpers');
 
+const bytesToMb = uploadingHelpers.bytesToMb;
+
 const User = require('../../models/index').User;
 const Upload = require('../../models/index').Upload;
 
@@ -270,7 +272,7 @@ exports.postFileUpload = async(req, res) => {
       let fileExtension = getExtensionString(filename);
 
       const fileSize = resumableTotalSize;
-      const originalFileSizeInMb = uploadingHelpers.bytesToMb(resumableTotalSize);
+      const originalFileSizeInMb = bytesToMb(resumableTotalSize);
 
       if(fileExtension == '.MP4'){
         fileExtension = '.mp4';
@@ -494,7 +496,7 @@ exports.postFileUpload = async(req, res) => {
 
               // Save file size after compression.
               const response = await ffmpegHelper.ffprobePromise(fileInDirectory);
-              upload.processedFileSizeInMb = uploadingHelpers.bytesToMb(response.format.size);
+              upload.processedFileSizeInMb = bytesToMb(response.format.size);
 
               await upload.save();
 
@@ -620,7 +622,7 @@ exports.adminUpload = async(req, res) => {
     // console.log(response);
 
     upload.fileSize = response.format.size;
-    upload.processedFileSizeInMb = uploadingHelpers.bytesToMb(response.format.size);
+    upload.processedFileSizeInMb = bytesToMb(response.format.size);
 
     upload.bitrate = response.format.bit_rate / 1000;
 

--- a/controllers/frontend/mediaPlayer.js
+++ b/controllers/frontend/mediaPlayer.js
@@ -117,7 +117,7 @@ exports.getMedia = async(req, res) => {
 
     var formattedFileSize; // formatted string that will be shown in the page
     if(bytesToGb(upload.processedFileSizeInMb) >= 1)
-      formattedFileSize = bytesToGb(upload.processedFileSizeInMb).toFixed(2) || bytesToGb(upload.originalFileSizeInGb).toFixed(2) + ' GB';
+      formattedFileSize = bytesToGb(upload.processedFileSizeInMb).toFixed(2) || bytesToGb(upload.originalFileSizeInMb).toFixed(2) + ' GB';
     else
       formattedFileSize = Math.round(upload.processedFileSizeInMb) || Math.round(upload.originalFileSizeInMb) + ' MB';
 

--- a/controllers/frontend/mediaPlayer.js
+++ b/controllers/frontend/mediaPlayer.js
@@ -11,6 +11,8 @@ const categories = require('../../config/categories');
 
 let uploadServer  = uploadHelpers.uploadServer;
 
+const _ = require('lodash');
+
 const generateComments = require('../../lib/mediaPlayer/generateCommentsObjects');
 const generateReactInfo = require('../../lib/mediaPlayer/generateReactInfo');
 const saveMetaToResLocal = require('../../lib/mediaPlayer/generateMetatags');
@@ -115,11 +117,27 @@ exports.getMedia = async(req, res) => {
     // console.log(upload);
     await upload.save();
 
-    var formattedFileSize; // formatted string that will be shown in the page
-    if(bytesToGb(upload.processedFileSizeInMb) >= 1)
-      formattedFileSize = bytesToGb(upload.processedFileSizeInMb).toFixed(2) || bytesToGb(upload.originalFileSizeInMb).toFixed(2) + ' GB';
-    else
-      formattedFileSize = Math.round(upload.processedFileSizeInMb) || Math.round(upload.originalFileSizeInMb) + ' MB';
+
+    // originalFileSizeInMb: Number,
+    // processedFileSizeInMb: Number,
+
+    function getFormattedFileSize(upload){
+      const fileSizeInMb = upload.originalFileSizeInMb || upload.processedFileSizeInMb;
+
+
+      let formattedFileSizeString;
+
+      // if it's under one gig,
+      if(fileSizeInMb < 1000){
+        formattedFileSizeString = fileSizeInMb + ' MB'
+      } else {
+        formattedFileSizeString  = _.round(fileSizeInMb/1000, 1) + ' GB'
+      }
+
+      return formattedFileSizeString
+    }
+
+    const formattedFileSize = getFormattedFileSize(upload);
 
     // document is fine to be shown publicly
 

--- a/controllers/frontend/mediaPlayer.js
+++ b/controllers/frontend/mediaPlayer.js
@@ -5,6 +5,8 @@ const timeHelper = require('../../lib/helpers/time');
 
 const uploadHelpers = require('../../lib/helpers/settings');
 
+const { bytesToGb } = require('../../lib/uploading/helpers')
+
 const categories = require('../../config/categories');
 
 let uploadServer  = uploadHelpers.uploadServer;
@@ -110,8 +112,17 @@ exports.getMedia = async(req, res) => {
     await view.save();
     upload.checkedViews.push(view);
 
+    if(upload.originalFileSizeInGb == undefined || upload.originalFileSizeInGb == null) // older versions didn't had file size in GB
+      upload.originalFileSizeInGb = bytesToGb(upload.fileSize)
+
     // console.log(upload);
     await upload.save();
+
+    var formattedFileSize; // formatted string that will be shown in the page
+    if(upload.originalFileSizeInGb >= 1)
+      formattedFileSize = (upload.processedFileSizeInGb.toFixed(2)) || (upload.originalFileSizeInGb.toFixed(2)) + ' GB';
+    else
+      formattedFileSize = (Math.round(upload.processedFileSizeInMb)) || (Math.round(upload.originalFileSizeInMb)) + ' MB';
 
     // document is fine to be shown publicly
 
@@ -144,7 +155,8 @@ exports.getMedia = async(req, res) => {
       getParameterByName,
       viewingUserIsBlocked,
       brandName,
-      secondsToFormattedTime
+      secondsToFormattedTime,
+      formattedFileSize
     });
 
   } catch(err){

--- a/controllers/frontend/mediaPlayer.js
+++ b/controllers/frontend/mediaPlayer.js
@@ -112,17 +112,14 @@ exports.getMedia = async(req, res) => {
     await view.save();
     upload.checkedViews.push(view);
 
-    if(upload.originalFileSizeInGb == undefined || upload.originalFileSizeInGb == null) // older versions didn't had file size in GB
-      upload.originalFileSizeInGb = bytesToGb(upload.fileSize)
-
     // console.log(upload);
     await upload.save();
 
     var formattedFileSize; // formatted string that will be shown in the page
-    if(upload.originalFileSizeInGb >= 1)
-      formattedFileSize = (upload.processedFileSizeInGb.toFixed(2)) || (upload.originalFileSizeInGb.toFixed(2)) + ' GB';
+    if(bytesToGb(upload.processedFileSizeInMb) >= 1)
+      formattedFileSize = bytesToGb(upload.processedFileSizeInMb).toFixed(2) || bytesToGb(upload.originalFileSizeInGb).toFixed(2) + ' GB';
     else
-      formattedFileSize = (Math.round(upload.processedFileSizeInMb)) || (Math.round(upload.originalFileSizeInMb)) + ' MB';
+      formattedFileSize = Math.round(upload.processedFileSizeInMb) || Math.round(upload.originalFileSizeInMb) + ' MB';
 
     // document is fine to be shown publicly
 

--- a/lib/uploading/helpers.js
+++ b/lib/uploading/helpers.js
@@ -73,6 +73,7 @@ function userCanUploadContentOfThisRating(maxRatingAllowed, contentRating) {
   }
 }
 
+// TODO: need an explanation of this math
 const bytesToMb = (bytes, decimalPlaces = 4) => {
   return(bytes / Math.pow(10,6)).toFixed(decimalPlaces);
 };

--- a/lib/uploading/helpers.js
+++ b/lib/uploading/helpers.js
@@ -73,11 +73,21 @@ function userCanUploadContentOfThisRating(maxRatingAllowed, contentRating) {
   }
 }
 
+const bytesToMb = (bytes, decimalPlaces = 4) => {
+  return(bytes / Math.pow(10,6)).toFixed(decimalPlaces);
+};
+
+const bytesToGb = (bytes, decimalPlaces = 4) => {
+  return(bytes / Math.pow(10,9)).toFixed(decimalPlaces);
+};
+
 module.exports = {
   markUploadAsComplete,
   updateUsersUnreadSubscriptions,
   runTimeoutFunction,
-  userCanUploadContentOfThisRating
+  userCanUploadContentOfThisRating,
+  bytesToMb,
+  bytesToGb
 };
 
 

--- a/models/Upload.js
+++ b/models/Upload.js
@@ -25,6 +25,8 @@ const uploadSchema = new mongoose.Schema({
   fileType: { type: String, enum: ['video', 'image', 'audio', 'unknown', 'convert'] },
   originalFileSizeInMb: Number,
   processedFileSizeInMb: Number,
+  originalFileSizeInGb: Number,
+  processedFileSizeInGb: Number,
   fileSize: Number,  // TODO: should support highQualityFileSize as well for compressions
   views: {
     type: Number,

--- a/models/Upload.js
+++ b/models/Upload.js
@@ -25,8 +25,6 @@ const uploadSchema = new mongoose.Schema({
   fileType: { type: String, enum: ['video', 'image', 'audio', 'unknown', 'convert'] },
   originalFileSizeInMb: Number,
   processedFileSizeInMb: Number,
-  originalFileSizeInGb: Number,
-  processedFileSizeInGb: Number,
   fileSize: Number,  // TODO: should support highQualityFileSize as well for compressions
   views: {
     type: Number,

--- a/views/media.pug
+++ b/views/media.pug
@@ -169,7 +169,7 @@ block content
                     if upload.fileType == 'video' || upload.fileType == 'audio'
 
                         // TODO: should be able to support MB and GB
-                        p.fw.fileSizeText(style="margin-top:15px") File Size: #{ Math.round(upload.processedFileSizeInMb) || ( upload.fileSize/ ( 1000 * 1000)).toFixed() } MB
+                        p.fw.fileSizeText(style="margin-top:15px") File Size: #{ formattedFileSize }
 
                     if upload.category
                         each category in categories


### PR DESCRIPTION
Closes #213 

Now GB file size is also saved in the database, and when it exceeds 1 GB it is shown to the user as GB instead of MB.