### PR TITLE
Embed code fix

### DIFF
--- a/controllers/frontend/mediaPlayer.js
+++ b/controllers/frontend/mediaPlayer.js
@@ -169,7 +169,8 @@ exports.getMedia = async(req, res) => {
       viewingUserIsBlocked,
       brandName,
       secondsToFormattedTime,
-      formattedFileSize
+      formattedFileSize,
+      domainName: process.env.DOMAIN_NAME_AND_TLD
     });
 
   } catch(err){

--- a/controllers/frontend/public.js
+++ b/controllers/frontend/public.js
@@ -107,7 +107,8 @@ exports.getEmbed = async function(req, res){
 
   res.render('public/embed', {
     title: 'Embed',
-    upload
+    upload,
+    protocolDomainNameAndTLD: process.env.DOMAIN_NAME_AND_TLD
   });
 };
 

--- a/views/mediaPlayerPartials/embedLinkFunctionalityJs.pug
+++ b/views/mediaPlayerPartials/embedLinkFunctionalityJs.pug
@@ -5,10 +5,12 @@ script.
 
   var fileType = '#{upload.fileType}';
 
-  var embedString = '<iframe width="560" height="315" src="https://nodetube.live/embed/' + uniqueTag + '" frameborder="0" allowfullscreen=""></iframe>'
+  var domainName = '#{domainName}';
+
+  var embedString = '<iframe width="560" height="315" src="' + domainName + '/embed/' + uniqueTag + '" frameborder="0" allowfullscreen=""></iframe>'
 
   if(fileType == 'audio'){
-    embedString = '<iframe width="560" height="54" src="https://nodetube.live/embed/' + uniqueTag + '" frameborder="0" allowfullscreen=""></iframe>'
+    embedString = '<iframe width="560" height="54" src="' + domainName + '/embed/' + uniqueTag + '" frameborder="0" allowfullscreen=""></iframe>'
   }
 
   $('.share-button').on('click', function(){

--- a/views/public/embed.pug
+++ b/views/public/embed.pug
@@ -89,7 +89,7 @@ html
                 video.display-element(poster=upload.thumbnailUrl controls='')
                     // TODO: Sub out thumbnail here
 
-                    source(src=`https://nodetube.live/uploads/${upload.uploader.channelUrl}/${upload.uniqueTag}.mp4`, type='video/mp4')
+                    source(src=`${protocolDomainNameAndTLD}/uploads/${upload.uploader.channelUrl}/${upload.uniqueTag}.mp4`, type='video/mp4')
                     source(src=upload.uploadUrl, type='video/mp4')
             else if upload.fileType == 'image'
                 img.display-element(src=upload.uploadUrl style="height:100%;width:100%")


### PR DESCRIPTION
Closes #208 

Embed code was hardcoded to nodetube.live. Now uses the domain name and TLD from the env file.