### PR TITLE
Corrects Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,29 @@ FROM node:10-alpine
 RUN apk add ffmpeg
 RUN apk add git
 RUN apk add tar
+# For youtube-dl
+RUN apk add python
 
-COPY package*.json /app/
+COPY app* package* .env.settings.sample .env.private.sample copySettingsAndPrivateFiles.js Procfile routes.js /app/
+COPY bin /app/bin/
+COPY caching /app/caching/
+COPY config /app/config/
+COPY controllers /app/controllers/
+COPY keys /app/keys/
+COPY lib /app/lib/
+COPY media /app/media/
+COPY middlewares /app/middlewares/
+COPY models /app/models/
+COPY public /app/public/
+COPY scripts /app/scripts/
+COPY views /app/views/
 
 WORKDIR /app/
 #RUN rm -rf ./node_modules
 #RUN npm cache clean --force
 #RUN npm i --production
-RUN npm i
+RUN npm i && nodejs ./copySettingsAndPrivateFiles.js
 #RUN npm rebuild node-sass
-
-COPY . .
 
 EXPOSE 8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,12 @@ services:
     ports:
       - "49161:3000"
     volumes:
-      - .:/app/
       - /app/node_modules
       - ./upload:/app/upload
       - ./uploads:/app/uploads
     environment:
       - REDIS_HOST=redis
-      - MONGODB_DOCKER_URI=mongodb://nodetube-mongo:27017/nodetube
+      - MONGODB_URI=mongodb://nodetube-mongo:27017/nodetube
     depends_on:
       - redis
       - mongo


### PR DESCRIPTION
This makes the shipped Dockerfile and docker-compose.yml "just work"

Usage: `docker-compose up 2>&1 | grep -v 'nodetube-mongo'`

This way the ngrok url shows as the last item in the scroll instead of a bunch of mongo scroll
