### PR TITLE
Fix/comments bug

### DIFF
--- a/lib/mediaPlayer/generateCommentsObjects.js
+++ b/lib/mediaPlayer/generateCommentsObjects.js
@@ -11,7 +11,7 @@ async function generateComments(uploadId){
     upload: uploadId,
     visibility: 'public',
     inResponseTo : {$exists: false}
-  }).populate({path: 'responses commenter', populate: {path: 'commenter'}});
+  }).populate({path: 'responses commenter', match: { visibility: { $ne: 'removed' } }, populate: {path: 'commenter'}});
 
   let commentCount = 0;
   for(const comment of comments){

--- a/views/media.pug
+++ b/views/media.pug
@@ -777,7 +777,7 @@ block content
                                                         // delete button
                                                         // if uploader or admin or commenter, let them delete comment
                                                         if isUploaderOrAdmin || ( user && comment.commenter._id == user._id )
-                                                            a.delete-comment-button(style="margin-left:9px;cursor:pointer;" commentId=comment._id) Delete
+                                                            a.delete-comment-thread-button(style="margin-left:9px;cursor:pointer;" commentId=comment._id) Delete
 
                                                         if isUploader && !comment.commenter.isBlocked
                                                             a.block-user-button(style="margin-left:9px;cursor:pointer;" blockedusername=comment.commenter.channelUrl) Block User

--- a/views/media.pug
+++ b/views/media.pug
@@ -773,7 +773,7 @@ block content
                                                         a(href=`/user/${comment.commenter.channelUrl}` style="color:#d2d2d2;margin-right:5px;") #{comment.commenter.channelName || comment.commenter.channelUrl}
                                                     p.fw(style="display:inline-block;") - #{comment.timeAgo} &nbsp
                                                         if user && !viewingUserIsBlocked
-                                                            a.reply-link(style="cursor:pointer") Reply
+                                                            a.reply-link(style="cursor:pointer") Comment in Thread
                                                         // delete button
                                                         // if uploader or admin or commenter, let them delete comment
                                                         if isUploaderOrAdmin || ( user && comment.commenter._id == user._id )

--- a/views/media.pug
+++ b/views/media.pug
@@ -807,6 +807,17 @@ block content
                                                                 p.fw(style="text-align:left;display:inline-block;")
                                                                     a(href=`/user/${responseComment.commenter.channelUrl}` style="color:#d2d2d2;margin-right:5px;") #{responseComment.commenter.channelName || responseComment.commenter.channelUrl}
                                                                 p.fw(style="display:inline-block;") - #{responseComment.timeAgo} &nbsp
+                                                                    // delete button
+                                                                    // if uploader, admin or commenter, let them delete comment
+                                                                    if isUploaderOrAdmin || ( user && comment.commenter._id == user._id )
+                                                                        a.delete-comment-button(style="margin-left:9px;cursor:pointer;" commentId=comment._id) Delete
+
+                                                                    // if uploader, allow (un)blocking a user
+                                                                    // uploader cannot (un)block themselves
+                                                                    if isUploader && !comment.commenter.isBlocked && ( user && comment.commenter._id != user._id )
+                                                                        a.block-user-button(style="margin-left:9px;cursor:pointer;" blockedusername=comment.commenter.channelUrl) Block User
+                                                                    if isUploader && comment.commenter.isBlocked && ( user && comment.commenter._id != user._id )
+                                                                        a.unblock-user-button(style="margin-left:9px;cursor:pointer;" blockedusername=comment.commenter.channelUrl) Unblock User
                                                             p.fw(style="text-align:left;") #{responseComment.text}
 
                                                         //div.reply-container(style="display:none")

--- a/views/media.pug
+++ b/views/media.pug
@@ -810,7 +810,7 @@ block content
                                                                     // delete button
                                                                     // if uploader, admin or commenter, let them delete comment
                                                                     if isUploaderOrAdmin || ( user && comment.commenter._id == user._id )
-                                                                        a.delete-comment-button(style="margin-left:9px;cursor:pointer;" commentId=comment._id) Delete
+                                                                        a.delete-thread-comment-button(style="margin-left:9px;cursor:pointer;" commentId=responseComment._id) Delete
 
                                                                     // if uploader, allow (un)blocking a user
                                                                     // uploader cannot (un)block themselves

--- a/views/mediaPlayerPartials/deleteCommentAndBlockUnblockUserJs.pug
+++ b/views/mediaPlayerPartials/deleteCommentAndBlockUnblockUserJs.pug
@@ -36,7 +36,7 @@ script.
 
     }
 
-    $('.delete-comment-button').on('release click', function (e) {
+    $('.delete-comment-thread-button').on('release click', function (e) {
 
       var commentThread = $(this).parent().parent().parent().parent();
 

--- a/views/mediaPlayerPartials/deleteCommentAndBlockUnblockUserJs.pug
+++ b/views/mediaPlayerPartials/deleteCommentAndBlockUnblockUserJs.pug
@@ -1,6 +1,6 @@
 script.
   $(function(){
-    function deleteComment(commentId, commentThread) {
+    function deleteComment(commentId, comment) {
 
       var upload = '#{upload._id}';
 
@@ -21,7 +21,7 @@ script.
 
           swal('Comment deleted!');
 
-          commentThread.hide();
+          comment.hide();
 
 
           // remove comment

--- a/views/mediaPlayerPartials/deleteCommentAndBlockUnblockUserJs.pug
+++ b/views/mediaPlayerPartials/deleteCommentAndBlockUnblockUserJs.pug
@@ -60,6 +60,30 @@ script.
       })
     })
 
+    $('.delete-thread-comment-button').on('release click', function (e) {
+
+      var threadComment = $(this).parent().parent().parent();
+
+      var commentId = $(this).attr('commentId');
+
+      // dont move browser
+      e.preventDefault();
+
+      swal({
+        title: "Delete Comment",
+        text: "Are you sure you want to delete the comment?",
+        type: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Delete Comment'
+      }).then(function (result) {
+        if (result.value) {
+          deleteComment(commentId, threadComment)
+        } else {
+          swal.close();
+        }
+      })
+    })
+
     function blockUser(blockedUsername) {
 
       var csrf = '#{_csrf}'


### PR DESCRIPTION
Addresses #304 

Changes made
Frontend
- [x] Change 'Reply' to 'Comment in Thread'.
- [x] Add 'Delete' and 'Block User' button to thread comments.
- [x] Update 'Delete' button pop up for thread comments.
- [ ] Number of comments decreases immediately when you delete a comment (not sure if this is possible).
- [ ] Hide the 'Block User' button for a user's own comments.

Backend
- [x] Delete thread comment functionality.
- [ ] Setting blocked users.

Bugs noted:
1. When a user is blocked, it's not possible to unblock them. There's some code that sets `isBlocked` in `generateCommentsObjects.js` but it has been commented out. I didn't want to fix this because I'm not sure what the deal is with the commented code.
2. Should line 731 in `internalApi.js` be 
```js
// Note the '||' instead of '&&'
function deleteComment() {
    ...
    if(!userIsUploader || !userIsCommenter){
      throw new Error('not the proper user');
    }
    ...
}
```