### PR TITLE
fixed video thumbnail uploads to backblaze

### DIFF
--- a/lib/uploading/ffmpeg.js
+++ b/lib/uploading/ffmpeg.js
@@ -62,8 +62,8 @@ function takeAndUploadThumbnail(uploadedPath, uniqueTag, upload, channelUrl, b2,
         // for b2 integration, upload to b2 if it's prod and you're supposed to
         if(process.env.NODE_ENV == 'production' && process.env.UPLOAD_TO_B2 == 'true'){
           (async function(){
-            const response = await b2.uploadFileAsync(`${saveAndServeFilesDirectory}/${channelUrl}/` + uniqueTag + '.png', {
-              name : hostFilePath + '.png',
+            const response = await b2.uploadFileAsync(`${saveAndServeFilesDirectory}/${channelUrl}/` + uniqueTag + '.jpg', {
+              name : hostFilePath + '.jpg',
               bucket // Optional, defaults to first bucket
             });
 


### PR DESCRIPTION
when nodetube auto-generated video thumbnails it creates them as jpg, but then tries to locate and upload it to backblaze as a png, resulting in a "file not found" error. so i simply changed it to locate a jpg and now it all works